### PR TITLE
subgroup priority for all units and buildings

### DIFF
--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Protoss_Buildings.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Protoss_Buildings.xml
@@ -1732,7 +1732,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <AIEvalFactor value="0.8"/>
@@ -1805,7 +1805,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="1.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_Stargate"/>
@@ -1874,7 +1874,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="11"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="217"/>
@@ -1942,7 +1942,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="14"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="217"/>
@@ -2075,7 +2075,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="10"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="214"/>
@@ -2140,7 +2140,7 @@
         <ScoreMake value="400"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="7"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="219"/>
@@ -2277,7 +2277,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/ProtossUnitsSCBW"/>
@@ -2410,7 +2410,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <LeaderAlias value="CyberneticsCore"/>
@@ -2483,7 +2483,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <LeaderAlias value="Forge"/>
@@ -2557,7 +2557,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="24"/>
         <MinimapRadius value="1.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkGatewaySCBW"/>
@@ -2621,7 +2621,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="18"/>
@@ -2653,7 +2653,7 @@
         <ScoreMake value="400"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="28"/>
         <MinimapRadius value="2.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <ResourceDropOff index="Minerals" value="1"/>
@@ -2755,7 +2755,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="12"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TacticalAI value="TwilightCouncil"/>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Protoss_Units.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Protoss_Units.xml
@@ -4811,7 +4811,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="69"/>
         <MinimapRadius value="0.875"/>
         <TacticalAIThink value="AIThinkShuttle"/>
         <AIEvalFactor value="0"/>
@@ -4930,7 +4930,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="51"/>
         <MinimapRadius value="1.25"/>
         <TacticalAI value="Carrier"/>
         <Mass value="0.6"/>
@@ -4996,7 +4996,7 @@
         <CargoSize value="4"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <GlossaryPriority value="90"/>
         <GlossaryStrongArray value="Mutalisk"/>
@@ -5055,7 +5055,7 @@
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>
-        <SubgroupPriority value="21"/>
+        <SubgroupPriority value="81"/>
         <MinimapRadius value="0.75"/>
         <GlossaryPriority value="160"/>
         <GlossaryStrongArray value="MissileTurret"/>
@@ -5131,7 +5131,7 @@
         <CargoSize value="4"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="87"/>
         <MinimapRadius value="0.75"/>
         <GlossaryPriority value="100"/>
         <GlossaryStrongArray value="Zealot"/>
@@ -5210,7 +5210,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="93"/>
         <MinimapRadius value="0.375"/>
         <TacticalAIThink value="AIThinkHighTemplarSCBW"/>
         <AIEvalFactor value="1.8"/>
@@ -5274,7 +5274,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="36"/>
         <AIEvalFactor value="0"/>
         <GlossaryPriority value="110"/>
         <GlossaryStrongArray value="Banshee"/>
@@ -5345,7 +5345,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="72"/>
         <MinimapRadius value="1"/>
         <Mass value="0.6"/>
         <GlossaryPriority value="130"/>
@@ -5397,7 +5397,7 @@
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="78"/>
         <MinimapRadius value="0.75"/>
         <GlossaryPriority value="140"/>
         <GlossaryStrongArray value="Battlecruiser"/>
@@ -5459,7 +5459,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="39"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="20"/>
         <GlossaryStrongArray value="Marauder"/>
@@ -5541,7 +5541,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="33"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="10"/>
     </CUnit>
@@ -5595,7 +5595,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="60"/>
         <MinimapRadius value="0.625"/>
         <GlossaryPriority value="50"/>
         <GlossaryStrongArray value="SiegeTankSieged"/>
@@ -5664,7 +5664,7 @@
         </CardLayouts>
         <Radius value="1"/>
         <SeparationRadius value="1"/>
-        <SubgroupPriority value="30"/>
+        <SubgroupPriority value="96"/>
         <MinimapRadius value="0.75"/>
         <GlossaryPriority value="160"/>
         <GlossaryStrongArray value="SiegeTank"/>
@@ -5734,7 +5734,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="56"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="70"/>
         <GlossaryStrongArray value="SCV"/>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Terran_Buildings.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Terran_Buildings.xml
@@ -2653,6 +2653,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="1.75"/>
         <GlossaryPriority value="326"/>
         <TechTreeUnlockedUnitArray value="GoliathSCBW"/>
@@ -2680,6 +2681,7 @@
         <Radius value="1.75"/>
         <SeparationRadius value="1.75"/>
         <ScoreKill value="150"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="1.75"/>
     </CUnit>
     <CUnit id="CommandCenterSCBW@Flying" parent="TerranBuildingSCBW@Flying" AliasUnit="CommandCenterSCBW">
@@ -2709,6 +2711,7 @@
         <Radius value="2.5"/>
         <SeparationRadius value="2.5"/>
         <ScoreKill value="400"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="2.5"/>
         <TechAliasArray index="0" value="Alias_CommandCenterSCBW"/>
     </CUnit>
@@ -2728,6 +2731,7 @@
         </CardLayouts>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
+        <SubgroupPriority value="31"/>
         <EnergyStart value="50"/>
         <EnergyMax value="200"/>
         <EnergyRegenRate value="0.5625"/>
@@ -2749,6 +2753,7 @@
         </CardLayouts>
         <ScoreMake value="75"/>
         <ScoreKill value="75"/>
+        <SubgroupPriority value="10"/>
     </CUnit>
     <CUnit id="CovertOpsSCBW" parent="TerranBuildingSCBW@AddOn" AddedOnUnit="ScienceFacilitySCBW">
         <LifeStart value="750"/>
@@ -2769,6 +2774,7 @@
         </CardLayouts>
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
+        <SubgroupPriority value="12"/>
         <TechTreeUnlockedUnitArray value="GhostSCBW"/>
     </CUnit>
     <CUnit id="EngineeringBaySCBW@Flying" parent="TerranBuildingSCBW@Flying" AliasUnit="EngineeringBaySCBW">
@@ -2790,6 +2796,7 @@
         <Radius value="1.25"/>
         <SeparationRadius value="1.25"/>
         <ScoreKill value="125"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1.75"/>
     </CUnit>
     <CUnit id="FactorySCBW@Flying" parent="TerranBuildingSCBW@Flying" AliasUnit="FactorySCBW">
@@ -2813,6 +2820,7 @@
         <Radius value="1.625"/>
         <SeparationRadius value="1.625"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="1.625"/>
     </CUnit>
     <CUnit id="NuclearSiloSCBW" parent="TerranBuildingSCBW@AddOnCC">
@@ -2832,6 +2840,7 @@
         </CardLayouts>
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
+        <SubgroupPriority value="30"/>
         <BuildTime value="50"/>
         <TacticalAIThink value="AIThinkNuclearSiloSCBW"/>
     </CUnit>
@@ -2852,6 +2861,7 @@
         </CardLayouts>
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
+        <SubgroupPriority value="13"/>
         <TechTreeUnlockedUnitArray value="BattlecruiserSCBW"/>
     </CUnit>
     <CUnit id="ScienceFacilitySCBW@Flying" parent="TerranBuildingSCBW@Flying" AliasUnit="ScienceFacilitySCBW">
@@ -2875,6 +2885,7 @@
         <Radius value="1.625"/>
         <SeparationRadius value="1.625"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="1"/>
         <MinimapRadius value="1.625"/>
     </CUnit>
     <CUnit id="StarportSCBW@Flying" parent="TerranBuildingSCBW@Flying" AliasUnit="StarportSCBW">
@@ -2898,6 +2909,7 @@
         <Radius value="1.625"/>
         <SeparationRadius value="1.625"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="2"/>
         <MinimapRadius value="1.625"/>
     </CUnit>
     <CUnit id="ScienceFacilitySCBW" parent="TerranBuildingSCBW">
@@ -2928,6 +2940,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="14"/>
         <MinimapRadius value="1.625"/>
         <TechAliasArray value="Alias_FactorySCBW"/>
         <GlossaryPriority value="322"/>
@@ -2954,6 +2967,7 @@
         </CardLayouts>
         <ScoreMake value="75"/>
         <ScoreKill value="75"/>
+        <SubgroupPriority value="11"/>
     </CUnit>
     <CUnit id="AcademySCBW" parent="TerranBuildingSCBW">
         <Facing value="315"/>
@@ -2980,6 +2994,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1.5"/>
         <TechAliasArray value="Alias_ShadowOps"/>
         <GlossaryPriority value="318"/>
@@ -3018,6 +3033,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="22"/>
         <MinimapRadius value="1.625"/>
         <TechAliasArray value="Alias_FactorySCBW"/>
         <GlossaryPriority value="322"/>
@@ -3096,6 +3112,7 @@
         <PlacementFootprint value="Footprint2x2"/>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
+        <SubgroupPriority value="1"/>
         <MinimapRadius value="0.75"/>
         <GlossaryCategory value="Unit/Category/TerranUnitsSCBW"/>
         <GlossaryPriority value="310"/>
@@ -3147,6 +3164,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
+        <SubgroupPriority value="9"/>
         <MinimapRadius value="1.75"/>
         <TacticalAIThink value="AIThinkBunkerSCBW"/>
         <AIEvalFactor value="1.1"/>
@@ -3193,6 +3211,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="1.75"/>
         <GlossaryPriority value="256"/>
         <Sight value="8"/>
@@ -3265,6 +3284,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="1.625"/>
         <TechAliasArray value="Alias_FactorySCBW"/>
         <GlossaryPriority value="322"/>
@@ -3297,6 +3317,7 @@
         <PlacementFootprint value="Footprint2x2"/>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
+        <SubgroupPriority value="1"/>
         <MinimapRadius value="1.25"/>
         <GlossaryPriority value="248"/>
         <Sight value="8"/>
@@ -3343,6 +3364,7 @@
         <PlacementFootprint value="Footprint5x5DropOff"/>
         <ScoreMake value="400"/>
         <ScoreKill value="400"/>
+        <SubgroupPriority value="32"/>
         <MinimapRadius value="2.5"/>
         <TacticalAIThink value="AIThinkCommandCenterSCBW"/>
         <TechAliasArray value="Alias_CommandCenterSCBW"/>
@@ -3377,6 +3399,7 @@
         <PlacementFootprint value="Footprint3x3"/>
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
+        <SubgroupPriority value="24"/>
         <MinimapRadius value="1.75"/>
         <GlossaryPriority value="252"/>
         <TechTreeProducedUnitArray value="MarineSCBW"/>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Terran_Units.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Terran_Units.xml
@@ -6014,7 +6014,7 @@
         <ScoreMake value="700"/>
         <ScoreKill value="700"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="80"/>
         <MinimapRadius value="1.25"/>
         <AIEvalFactor value="0.9"/>
         <Mass value="0.6"/>
@@ -6082,7 +6082,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="84"/>
         <MinimapRadius value="0.625"/>
         <GlossaryPriority value="180"/>
         <KillDisplay value="Always"/>
@@ -6141,7 +6141,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="60"/>
         <MinimapRadius value="0.75"/>
         <AIEvalFactor value="0.2"/>
         <GlossaryPriority value="185"/>
@@ -6192,7 +6192,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="275"/>
         <ScoreKill value="275"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="52"/>
         <MinimapRadius value="0.65"/>
         <GlossaryPriority value="100"/>
         <GlossaryStrongArray value="BattlecruiserSCBW"/>
@@ -6249,7 +6249,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="62"/>
         <MinimapRadius value="0.625"/>
         <GlossaryPriority value="160"/>
         <GlossaryStrongArray value="WraithSCBW"/>
@@ -6307,7 +6307,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="68"/>
         <MinimapRadius value="0.625"/>
         <TacticalAIThink value="AIThinkWraithSCBW"/>
         <GlossaryPriority value="160"/>
@@ -6379,7 +6379,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="58"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="10"/>
         <Fidget>
@@ -6438,7 +6438,7 @@
         <ScoreMake value="275"/>
         <ScoreKill value="275"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="74"/>
         <MinimapRadius value="1"/>
         <AIEvalFactor value="1.5"/>
         <TechAliasArray value="Alias_SiegeTankSCBW"/>
@@ -6499,7 +6499,7 @@
         <InnerRadius value="0.875"/>
         <Footprint value="FootprintSieged"/>
         <ScoreKill value="275"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="74"/>
         <MinimapRadius value="1"/>
         <AIEvalFactor value="1.5"/>
         <TechAliasArray value="Alias_SiegeTankSCBW"/>
@@ -6557,7 +6557,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="100"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="66"/>
         <MinimapRadius value="0.625"/>
         <TacticalAIThink value="AIThinkVultureSCBW"/>
         <GlossaryPriority value="90"/>
@@ -6636,7 +6636,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="82"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Ghost"/>
@@ -6697,7 +6697,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="115"/>
         <ScoreKill value="115"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="76"/>
         <GlossaryPriority value="40"/>
         <GlossaryStrongArray value="SCVSCBW"/>
         <GlossaryStrongArray value="ZerglingSCBW"/>
@@ -6768,7 +6768,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="82"/>
         <MinimapRadius value="0.375"/>
         <AIEvalFactor value="1.2"/>
         <GlossaryPriority value="70"/>
@@ -6827,7 +6827,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="78"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="21"/>
         <GlossaryStrongArray value="FirebatSCBW"/>
@@ -6893,7 +6893,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="70"/>
         <MinimapRadius value="0.375"/>
         <GlossaryPriority value="30"/>
         <Fidget>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Zerg_Buildings.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Zerg_Buildings.xml
@@ -2344,7 +2344,7 @@
         <ScoreMake value="900"/>
         <ScoreKill value="950"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="35"/>
         <MinimapRadius value="2.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TacticalAI value="HatcherySCBW"/>
@@ -2537,7 +2537,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="10"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>
@@ -2596,7 +2596,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>
@@ -2654,7 +2654,7 @@
         <ScoreMake value="650"/>
         <ScoreKill value="700"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="24"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_SpireSCBW"/>
@@ -2716,7 +2716,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="12"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>
@@ -2775,7 +2775,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="125"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="26"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>
@@ -2835,7 +2835,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_HydraliskDen"/>
@@ -2914,7 +2914,7 @@
         <ScoreMake value="550"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="34"/>
         <MinimapRadius value="2.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TacticalAI value="HatcherySCBW"/>
@@ -2974,7 +2974,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>
@@ -3049,7 +3049,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="33"/>
         <MinimapRadius value="2.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>
@@ -3112,7 +3112,7 @@
         <ScoreMake value="400"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="22"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_SpireSCBW"/>
@@ -3179,7 +3179,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="125"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkCrawler"/>
@@ -3249,7 +3249,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <AIEvalFactor value="0.65"/>
@@ -3317,7 +3317,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <AIEvalFactor value="0.65"/>
@@ -3377,7 +3377,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="2"/>
+        <SubgroupPriority value="14"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryCategory value=""/>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Zerg_Units.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/SCBW/Zerg_Units.xml
@@ -2198,7 +2198,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="96"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkQueenSCBW"/>
@@ -2271,7 +2271,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="60"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="20"/>
@@ -2330,7 +2330,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="70"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="2"/>
         <GlossaryPriority value="70"/>
@@ -2404,7 +2404,7 @@
         <ScoreMake value="450"/>
         <ScoreKill value="900"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="90"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="170"/>
@@ -2471,7 +2471,7 @@
         <ScoreMake value="25"/>
         <ScoreKill value="25"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="68"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="50"/>

--- a/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/SC Evo Complete/SCEvo_Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -647,7 +647,7 @@
         <Radius value="0.625"/>
         <SeparationRadius value="0.625"/>
         <ScoreKill value="550"/>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="54"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <HotkeyAlias value=""/>
@@ -692,7 +692,7 @@
         <Radius value="0.625"/>
         <SeparationRadius value="0.625"/>
         <ScoreKill value="550"/>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="54"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <HotkeyAlias value=""/>
@@ -735,7 +735,7 @@
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="62"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>
@@ -779,6 +779,7 @@
         <PlacementFootprint value="Footrpint5x5CreepNormal"/>
         <ScoreMake value="400"/>
         <ScoreKill value="400"/>
+        <SubgroupPriority value="27"/>
         <MinimapRadius value="2.5"/>
         <TacticalAIThink value="AIThinkInfestedCommandCenterSCBW"/>
         <GlossaryPriority value="30"/>
@@ -811,6 +812,7 @@
         <Radius value="2.5"/>
         <SeparationRadius value="2.5"/>
         <ScoreKill value="400"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="2.5"/>
         <TechAliasArray index="0" value="Alias_InfestedCommandCenterSCBW"/>
         <LifeRegenRate value="0.25"/>
@@ -860,7 +862,7 @@
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
         <CargoSize value="1"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="82"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="219"/>
@@ -910,7 +912,7 @@
         <Radius value="0.625"/>
         <SeparationRadius value="0"/>
         <CargoSize value="1"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="82"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="BanelingBurrowed"/>
@@ -980,7 +982,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.25"/>
         <ScoreKill value="900"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="90"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="LurkerMP"/>
@@ -1044,7 +1046,7 @@
         </CardLayouts>
         <Radius value="0.875"/>
         <SeparationRadius value="0.875"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="84"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryStrongArray value="Battlecruiser"/>
@@ -1100,7 +1102,7 @@
         <GlossaryPriority value="140"/>
         <BuildTime value="37.5"/>
         <TacticalAIThink value="AIThinkGuardianSCBW"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="78"/>
     </CUnit>
     <CUnit id="LurkerSCBWEgg">
         <DeathRevealRadius value="3"/>
@@ -1139,7 +1141,7 @@
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="Rally,Rally1" Row="2" Column="4"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
         </CardLayouts>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="54"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
     </CUnit>
     <CUnit id="MutaliskSCBW" parent="ZergUnitSCBW">
@@ -1187,7 +1189,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="76"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="130"/>
         <GlossaryStrongArray value="VikingFighter"/>
@@ -1245,7 +1247,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="64"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value=""/>
@@ -1320,7 +1322,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="94"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.8"/>
@@ -1376,7 +1378,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="94"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.8"/>
@@ -1432,7 +1434,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="72"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>
@@ -1473,7 +1475,7 @@
             <LayoutButtons Face="CancelCocoon" Type="AbilCmd" AbilCmd="que1,CancelLast" Row="2" Column="4"/>
             <LayoutButtons Face="AcquireMove" Type="AbilCmd" AbilCmd="move,AcquireMove" Row="0" Column="4"/>
         </CardLayouts>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="54"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value=""/>
         <HotkeyAlias value="Larva"/>
@@ -1509,7 +1511,7 @@
         </CardLayouts>
         <Radius value="0.125"/>
         <SeparationRadius value="0"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="58"/>
         <MinimapRadius value="0.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>
@@ -1559,7 +1561,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.375"/>
         <ScoreKill value="50"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="60"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="DroneSCBW"/>
@@ -1609,7 +1611,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.375"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="70"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="HydraliskSCBW"/>
         <HotkeyAlias value="HydraliskSCBW"/>
@@ -1648,7 +1650,6 @@
         <AbilArray Link="move"/>
         <ScoreMake value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Projectile,ObjectFamily:Melee"/>
         <Food value="-8"/>
     </CUnit>
@@ -1721,7 +1722,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="88"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkUltraliskSCBW"/>
@@ -1782,7 +1783,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="500"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="88"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkUltraliskSCBW"/>
@@ -1975,7 +1976,7 @@
         <Radius value="0.375"/>
         <SeparationRadius value="0"/>
         <ScoreKill value="25"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="68"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="ZerglingSCBW"/>


### PR DESCRIPTION
Set priority based on VoidMulti related units, with a few minor exceptions:
* creep colony before sunken/spore in order to facilitate morphing
* hatchery/lair/hive higher than nexus and command center (really only relevant for mind controlled bases or multi-race missions)
* greater spire before normal spire to avoid accidentally morphing more than you intended (analogous to the recent SC2 patch where hatch/lair/hive prio was swapped)
* comsat directly after CC to make scans as SC2-natural as possible (also consider adding a "send to selection" button to CC so you can scan with SC2 muscle memory)
  * this means nuke silo also comes immediately after comsat